### PR TITLE
fix table names

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -45,7 +45,7 @@ class Component extends BaseComponent
                 ->setIncremental(true)
                 ->setPrimaryKeyColumns(['id']);
 
-            $this->getManifestManager()->writeTableManifest('profiles', $outTableManifestOptions);
+            $this->getManifestManager()->writeTableManifest('profiles.csv', $outTableManifestOptions);
 
             $output = new Output($this->getDataDir());
             $output->writeProfiles(

--- a/src/Extractor/Output.php
+++ b/src/Extractor/Output.php
@@ -63,7 +63,7 @@ class Output
 
     public function createReport(array $query): CsvFile
     {
-        $csv = $this->createCsvFile(sprintf('%s_%s', $query['outputTable'], uniqid()));
+        $csv = $this->createCsvFile($query['outputTable']);
         $csv->writeRow($this->createHeaderRowFromQuery($query));
         return $csv;
     }

--- a/tests/Keboola/GoogleAnalyticsExtractor/ApplicationTest.php
+++ b/tests/Keboola/GoogleAnalyticsExtractor/ApplicationTest.php
@@ -375,7 +375,7 @@ class ApplicationTest extends TestCase
 
         return $finder->files()
             ->in($this->dataDir . '/out/tables')
-            ->name('/^' . $queryName . '.*\.manifest$/i')
+            ->name('/^' . $queryName . '.*\.csv.manifest$/i')
         ;
     }
 


### PR DESCRIPTION
- Název manifest souboru musí obsahovat název CSVčka včetně přípony
- uniqid() v názvu souboru už není potřeba