### PR TITLE
properties: use `name` key for metrics

### DIFF
--- a/src/Extractor/Output.php
+++ b/src/Extractor/Output.php
@@ -66,7 +66,8 @@ class Output
         }, $query['query']['dimensions']);
 
         $metrics = array_map(function ($item) {
-            return str_replace('ga:', '', $item['expression']);
+            $metric = $item['expression'] ?? $item['name'];
+            return str_replace('ga:', '', $metric);
         }, $query['query']['metrics']);
 
         return array_merge(

--- a/tests/Keboola/GoogleAnalyticsExtractor/Extractor/ExtractorTest.php
+++ b/tests/Keboola/GoogleAnalyticsExtractor/Extractor/ExtractorTest.php
@@ -133,7 +133,7 @@ class ExtractorTest extends TestCase
             }
             foreach ($metrics as $metric) {
                 Assert::assertContains(
-                    $metric['expression'],
+                    $metric['name'],
                     $header
                 );
             }

--- a/tests/data/config_properties.json
+++ b/tests/data/config_properties.json
@@ -13,12 +13,10 @@
     "query": {
       "metrics": [
         {
-          "name": "users",
-          "expression": "totalUsers"
+          "name": "totalUsers"
         },
         {
-          "name": "pageviews",
-          "expression": "itemViews"
+          "name": "itemViews"
         }
       ],
       "dimensions": [


### PR DESCRIPTION
https://keboola.slack.com/archives/CMTBFNLF8/p1622106605148800?thread_ts=1622019288.121600&cid=CMTBFNLF8

v Properties u metric jde použít jen `name` a `expression` se u defaultních metrik nemusí vyplňovat